### PR TITLE
adicionado caminho completo 'libs.slaxml' no require de slaxdom

### DIFF
--- a/libs/slaxdom.lua
+++ b/libs/slaxdom.lua
@@ -1,5 +1,5 @@
 -- Optional parser that creates a flat DOM from parsing
-local SLAXML = require 'slaxml'
+local SLAXML = require 'libs.slaxml'
 function SLAXML:dom(xml,opts)
 	if not opts then opts={} end
 	local rich = not opts.simple


### PR DESCRIPTION
No arquivo slaxdom.lua existia a seguinte chamada:
```lua 
 local SLAXML = require 'slaxml'
```
Porém, como o arquivo slaxml.lua também está na pasta libs, estava dando erro de módulo não encontrado. A chamada teve que ser mudada para o caminho completo:

```lua 
 local SLAXML = require 'libs.slaxml'
```
